### PR TITLE
feat: redirect players after the fight an overall class refactor

### DIFF
--- a/assets/Fighter.js
+++ b/assets/Fighter.js
@@ -15,12 +15,8 @@ export default class Fighter extends Sprite {
         this.height    = 0;
         this.width     = 0;
         this.isAttacking;
-        this.health = 100;
         this.curFrame = 0;
         this.sprites = sprites;
-        this.isReversed = false;
-        this.lastSprite = 'idle';
-        this.alive = true;
         this.defeatKnock = {
             x: 0,
             y: 0
@@ -41,6 +37,14 @@ export default class Fighter extends Sprite {
             sprites[sprite].image.src  = sprites[sprite].imgSrc;
             sprites[sprite].imageR.src = sprites[sprite].imgSrc.split('.png')[0] + '_r.png';
         }
+    }
+
+    reset() {
+        this.health     = 100;
+        this.alive      = true;
+        this.lastSprite = 'idle';
+        this.isReversed = false;
+        this.facing     = 'right';
     }
 
     changePosition(position) {

--- a/canvas/canvas.js
+++ b/canvas/canvas.js
@@ -6,13 +6,14 @@ const CANVAS_HEIGHT = 576;
 const globalData = {
     animFramId: null,
     currentScene: null,
-    next: 'firstscreen',
+    next: 'mainmenu',
     ST: null,
     P1: null,
     P2: null,
     gameLoading: true,
-    version: '0.7.5',
-    musicTransitionTime: null
+    version: '0.8.5',
+    musicTransitionTime: null,
+    delay: null
 }
 
 const canvas = document.querySelector('canvas');

--- a/index.js
+++ b/index.js
@@ -7,7 +7,35 @@ import PressStart from "./events/PressStart.js";
 import MainMenu from "./events/MainMenu.js";
 import HowToPlay from "./events/HowToPlay.js";
 
-async function animate() {
+// Characters
+import Thunder from './assets/Characters/Thunder.js';
+import Gonza from './assets/Characters/Gonza.js';
+
+// Stages
+import Barriers from './assets/Stages/Barriers.js';
+import Carrier from './assets/Stages/Carrier.js';
+import ColdFields from './assets/Stages/ColdFields.js';
+import ControlRoom from './assets/Stages/ControlRoom.js';
+import GinarzasHq from './assets/Stages/GinarzasHq.js';
+import Hangar from './assets/Stages/Hangar.js';
+import MiningSite from './assets/Stages/MiningSite.js';
+
+const characters = {
+    Thunder,
+    Gonza
+};
+
+const stages = {
+    Barriers,
+    Carrier,
+    ColdFields,
+    ControlRoom,
+    GinarzasHq,
+    Hangar,
+    MiningSite
+}
+
+function animate() {
     globalData.animFramId = window.requestAnimationFrame(animate);
 
     if (globalData.next) {
@@ -34,11 +62,12 @@ async function animate() {
                 globalData.currentScene = new CharacterSelect();
                 break;
             case 'fight':
-                const Player = await import(`./assets/Characters/${globalData.P1.class}.js`);
-                const Enemy  = await import(`./assets/Characters/${globalData.P2.class}.js`);
-                const Stage  = await import(`./assets/Stages/${globalData.ST}.js`);
-
-                globalData.currentScene = new Fight(Player.default, Enemy.default, Stage.default);
+                globalData.currentScene = new Fight(
+                    characters[globalData.P1.class],
+                    characters[globalData.P2.class],
+                    stages[globalData.ST]
+                );
+                globalData.currentScene.reset();
                 break;
             default:
                 break;
@@ -46,7 +75,9 @@ async function animate() {
 
         globalData.next = null;
     }
-    
+
+    // Delay handler - delay only works if a limit number is set
+    if (typeof globalData.delay === 'number') globalData.delay ++;
     globalData.currentScene.animate();
 
 }


### PR DESCRIPTION
Added a feature to redirect players back to the Character Select screen after each fight.
Changed the way that Stages and Fighters are imported in order to fix various bugs.
Added 'delay' variable on canvas to avoid using setTimeout.
Added 'reset' function on 'Fighter' and 'Fight' classes in order to easily restore an object to its initial state.